### PR TITLE
Made VGA color inputs go to counters

### DIFF
--- a/top-level.sv
+++ b/top-level.sv
@@ -5,38 +5,38 @@
 */
 
 module top-level
-		(input clock50MHz);
+		(input clock50MHz,
+		 input NESDataYellow,
+		 output vgaHsync, vgaVsync,
+		 output vgaOutRed, vgaOutGreen, vgaOutBlue);
 
 	NesReader NesReader1 (
-		.dataYellow(),
+		.dataYellow(NESDataYellow),
 		.clock(),
 		.reset_n(),
 		.latchOrange(),
 		.clockRed(),
-		.up(),
-		.down(),
-		.left(),
-		.right(),
-		.start(),
-		.select(),
-		.a(),
-		.b()
+		.up(NESUp),
+		.down(NESDown),
+		.left(NESLeft),
+		.right(NESRight),
+		.start(NESStart),
+		.select(NESSelect),
+		.a(NESA),
+		.b(NESB)
 	);
-		
+
 	vgaOutput vgaOutput1 (
 		.clock50MHz(clock50MHz),
-		.inReset(),
-		.redSwitch1(),
-		.redSwitch2(),
-		.greenSwitch1(),
-		.greenSwitch2(),
-		.blueSwitch1(),
-		.blueSwitch2(),
-		.hsync(),
-		.vsync(),
-		.outRed(),
-		.outGreen(),
-		.outBlue()
+		.inReset(NESStart),
+		.inRed(NESUp),
+		.inGreen(NESLeft),
+		.inBlue(NESRight),
+		.hSync(vgaVsync),
+		.vSync(vgaHsync),
+		.outRed(vgaOutRed),
+		.outGreen(vgaOutGreen),
+		.outBlue(vgaOutBlue)
 	);
 
 endmodule

--- a/vga_output.sv
+++ b/vga_output.sv
@@ -7,24 +7,31 @@
 module vgaOutput
 		(input clock50MHz,
 		 input inReset,
-		 input redSwitch1, redSwitch2,
-		 input greenSwitch1, greenSwitch2,
-		 input blueSwitch1, blueSwitch2,
+		 input inRed,
+		 input inGreen,
+		 input inBlue,
 		 output hSync,
 		 output vSync,
 		 output [3:0] outRed, outGreen, outBlue);
 	
-	logic [3:0] inRed, inGreen, inBlue;
+	counter #(.N(4)) redCounter (
+		.clk(inRed),
+		.reset(inReset),
+		.q(redCount)
+	);
 	
-	assign inRed[3:2] = {2{redSwitch1}};
-	assign inRed[1:0] = {2{redSwitch2}};
+	counter #(.N(4)) greenCounter (
+		.clk(inGreen),
+		.reset(inReset),
+		.q(greenCount)
+	);
 	
-	assign inGreen[3:2] = {2{greenSwitch1}};
-	assign inGreen[1:0] = {2{greenSwitch2}};
-	
-	assign inBlue[3:2] = {2{blueSwitch1}};
-	assign inBlue[1:0] = {2{blueSwitch2}};
-		 
+	counter #(.N(4)) blueCounter (
+		.clk(inBlue),
+		.reset(inReset),
+		.q(blueCount)
+	);
+
 	clockmod clockDivider(
 		.clock50MHz(clock50MHz),
 		.inReset(~inReset),
@@ -55,9 +62,9 @@ module vgaOutput
 	
 	displayMux display (
 		.select(hSignal & vSignal),
-		.inRed(inRed),
-		.inGreen(inGreen),
-		.inBlue(inBlue),
+		.inRed(redCount),
+		.inGreen(greenCount),
+		.inBlue(blueCount),
 		.outRed(outRed),
 		.outGreen(outGreen),
 		.outBlue(outBlue)


### PR DESCRIPTION
VGA colors are now driven by counters: pressing the appropriate button on the controller will increment the matching 4-bit color value.